### PR TITLE
Remove explicit line-clamp plugin inclusion as it is now default

### DIFF
--- a/R/use_tailwind.R
+++ b/R/use_tailwind.R
@@ -34,7 +34,7 @@
 #' @return a list of type `shiny.tag` with head and script elements needed to
 #'   run a tailwind app
 #' @export
-#' 
+#'
 #' @examples
 #' library(shiny)
 #' example_apps <- list.files(system.file("examples", package = "shiny.tailwind"),
@@ -57,7 +57,7 @@ use_tailwind <- function(css = NULL, tailwindConfig = NULL) {
   }
 
   # https://tailwindcss.com/docs/installation/play-cdn
-  url <- "https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio,line-clamp"
+  url <- "https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"
 
   html_cdn <- list(htmltools::HTML(sprintf(
     "<!-- Include CDN JavaScript -->\n<script src='%s'></script>",


### PR DESCRIPTION
Updates `use_tailwind()` tailwind url to exclude the `line-clamp` plugin as it is now included in Tailwind by default as of V3.3. Removes the following warnings from the devtools console when using shiny.tailwind.
<img width="437" alt="image" src="https://user-images.githubusercontent.com/46704616/230954797-9d750123-b193-4833-95f9-ba620a69cefe.png">
