### PR TITLE
Restores the ability for `install_tailwind_cli` to find and download the latest CLI version

### DIFF
--- a/R/tailwind_cli.R
+++ b/R/tailwind_cli.R
@@ -53,12 +53,12 @@ install_tailwindcss_cli <- function(overwrite = FALSE, version = "latest", verbo
   )
 
   # 3) get latest release version
-  url <- "https://github.com/tailwindlabs/tailwindcss/releases"
+  url <- "https://github.com/tailwindlabs/tailwindcss/releases/"
   if(version == "latest") {
-    html <- readLines(url)
+    html <- readLines(paste0(url, "latest"))
     h1 <- html[grepl("\\<h1\\>", html)][1]
     # Extract release version
-    version <- gsub(".*releases/tag/(v[0-9]+.[0-9]+.[0-9]+).*", "\\1", h1)
+    version <- gsub(".*(v[0-9]+.[0-9]+.[0-9]+).*", "\\1", h1)
   }
   if(verbose) {
     cat(paste0(


### PR DESCRIPTION
Modifies the code that finds the latest Tailwind version in `install_tailwind_cli` so it works again.